### PR TITLE
Fix missing rider gender route import

### DIFF
--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -8,7 +8,6 @@ import teamsRoutes from "./teams.routes";
 import racesRoutes from "./races.routes";
 import authRoutes from "./auth.routes";
 import leaderboardRoutes from "./leaderboard.routes";
-import riderGenderRoutes from "./rider-gender.routes";
 import { upload, processImage, downloadImage } from "../imageUpload";
 import path from "path";
 
@@ -21,7 +20,6 @@ export async function registerRoutes(app: Express): Promise<Server> {
   app.use("/api/races", racesRoutes);
   app.use("/api/auth", authRoutes);
   app.use("/api/leaderboard", leaderboardRoutes);
-  app.use("/api/rider-gender", riderGenderRoutes);
 
   // Static file serving
   app.use("/uploads", (req, res, next) => {


### PR DESCRIPTION
## Summary
- remove rider gender route from router

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6870bb5acd8c8322b4fe2b4d4f41ca0c